### PR TITLE
Initial commit / v 1.0.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+#
+# Exclude these files from release archives.
+# https://blog.madewithlove.be/post/gitattributes/
+#
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/.github export-ignore
+
+#
+# Auto detect text files and perform LF normalization
+# http://davidlaing.com/2012/09/19/customise-your-gitattributes-to-become-a-git-ninja/
+#
+* text=auto

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,11 @@
+<!--
+This repository is only for the Joomla PHPCompatibility ruleset, which prevents false positives from the PHPCompatibility standard by excluding back-fills and poly-fills which are included by Joomla.
+
+If your issue is related to the PHPCompatibility sniffs, please open an issue in the PHPCompatibility repository: https://github.com/PHPCompatibility/PHPCompatibility/issues
+
+Before opening a new issue, please search for duplicate issues to prevent opening a duplicate. If there is already an open issue, please leave a comment there.
+
+If you are opening an issue to get a new back-fill / poly-fill which was added to Joomla excluded, please include links to the Joomla source code to substantiate your request.
+
+Thanks!
+-->

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,47 @@
+sudo: false
+
+dist: trusty
+
+cache:
+  apt: true
+
+language: php
+
+## Cache composer downloads.
+cache:
+  directories:
+    # Cache directory for older Composer versions.
+    - $HOME/.composer/cache/files
+    # Cache directory for more recent Composer versions.
+    - $HOME/.cache/composer/files
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 7.2
+      addons:
+        apt:
+          packages:
+            - libxml2-utils
+    - php: 5.4
+
+before_install:
+  # Speed up build time by disabling Xdebug when its not needed.
+  - if [[ $COVERALLS_VERSION == "notset" ]]; then phpenv config-rm xdebug.ini || echo 'No xdebug config.'; fi
+  - export XMLLINT_INDENT="    "
+  - composer install
+
+script:
+  - |
+    if [[ $TRAVIS_PHP_VERSION == "7.2" ]]; then
+      # Validate the xml file.
+      # @link http://xmlsoft.org/xmllint.html
+      xmllint --noout ./PHPCompatibilityJoomla/ruleset.xml
+
+      # Check the code-style consistency of the xml file.
+      diff -B ./PHPCompatibilityJoomla/ruleset.xml <(xmllint --format "./PHPCompatibilityJoomla/ruleset.xml")
+    fi
+
+  # Validate the composer.json file.
+  # @link https://getcomposer.org/doc/03-cli.md#validate
+  - composer validate --no-check-all --with-dependencies --strict

--- a/PHPCompatibilityJoomla/ruleset.xml
+++ b/PHPCompatibilityJoomla/ruleset.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0"?>
+<ruleset name="PHPCompatibilityJoomla">
+    <description>Joomla specific ruleset which checks for PHP cross version compatibility.</description>
+
+    <!--
+    The Joomla minimum PHP requirement is PHP 5.3.10.
+    Add the following in your project PHPCS ruleset to enforce this:
+    <config name="testVersion" value="5.3-"/>
+
+    This directive is not included in this ruleset as individual projects may use
+    a different (higher) minimum PHP version.
+    -->
+
+    <rule ref="PHPCompatibility">
+        <!-- Via `ircmaxell/password-compat` -->
+        <exclude name="PHPCompatibility.PHP.NewConstants.password_bcryptFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.password_bcrypt_default_costFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.password_defaultFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.password_get_infoFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.password_hashFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.password_needs_rehashFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.password_verifyFound"/>
+
+        <!-- Via `joomla/compat` -->
+        <exclude name="PHPCompatibility.PHP.NewClasses.callbackfilteriteratorFound"/>
+        <exclude name="PHPCompatibility.PHP.NewInterfaces.jsonserializableFound"/>
+
+        <!-- Via `paragonie/random_compat` -->
+        <exclude name="PHPCompatibility.PHP.NewClasses.errorFound"/>
+        <exclude name="PHPCompatibility.PHP.NewClasses.typeerrorFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.random_intFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.random_bytesFound"/>
+
+        <!-- Via `paragonie/sodium_compat` -->
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_aead_chacha20poly1305_keybytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_aead_chacha20poly1305_nsecbytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_aead_chacha20poly1305_npubbytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_aead_chacha20poly1305_abytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_aead_aes256gcm_keybytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_aead_aes256gcm_nsecbytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_aead_aes256gcm_npubbytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_aead_aes256gcm_abytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_aead_chacha20poly1305_ietf_keybytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_aead_chacha20poly1305_ietf_nsecbytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_aead_chacha20poly1305_ietf_npubbytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_aead_chacha20poly1305_ietf_abytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_auth_bytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_auth_keybytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_box_sealbytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_box_secretkeybytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_box_publickeybytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_box_keypairbytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_box_macbytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_box_noncebytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_box_seedbytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_kx_bytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_kx_publickeybytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_kx_secretkeybytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_kx_seedbytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_generichash_bytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_generichash_bytes_minFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_generichash_bytes_maxFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_generichash_keybytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_generichash_keybytes_minFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_generichash_keybytes_maxFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_pwhash_saltbytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_pwhash_strprefixFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_pwhash_alg_argon2i13Found"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_pwhash_alg_argon2id13Found"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_pwhash_memlimit_interactiveFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_pwhash_opslimit_interactiveFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_pwhash_memlimit_moderateFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_pwhash_opslimit_moderateFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_pwhash_memlimit_sensitiveFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_pwhash_opslimit_sensitiveFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_scalarmult_bytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_scalarmult_scalarbytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_shorthash_bytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_shorthash_keybytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_secretbox_keybytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_secretbox_macbytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_secretbox_noncebytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_sign_bytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_sign_seedbytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_sign_publickeybytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_sign_secretkeybytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_sign_keypairbytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_stream_keybytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_stream_noncebytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_bin2hexFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_compareFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_aead_aes256gcm_decryptFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_aead_aes256gcm_encryptFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_aead_aes256gcm_is_availableFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_aead_chacha20poly1305_decryptFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_aead_chacha20poly1305_encryptFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_aead_chacha20poly1305_keygenFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_aead_chacha20poly1305_ietf_decryptFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_aead_chacha20poly1305_ietf_encryptFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_aead_chacha20poly1305_ietf_keygenFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_aead_xchacha20poly1305_ietf_decryptFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_aead_xchacha20poly1305_ietf_encryptFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_aead_xchacha20poly1305_ietf_keygenFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_authFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_auth_keygenFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_auth_verifyFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_boxFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_box_keypairFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_box_keypair_from_secretkey_and_publickeyFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_box_openFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_box_publickeyFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_box_publickey_from_secretkeyFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_box_sealFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_box_seal_openFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_box_secretkeyFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_box_seed_keypairFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_generichashFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_generichash_finalFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_generichash_initFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_generichash_keygenFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_generichash_updateFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_kxFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_pwhashFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_pwhash_strFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_pwhash_str_verifyFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_pwhash_scryptsalsa208sha256Found"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_pwhash_scryptsalsa208sha256_strFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_pwhash_scryptsalsa208sha256_str_verifyFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_scalarmultFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_scalarmult_baseFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_secretboxFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_secretbox_keygenFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_secretbox_openFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_shorthashFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_shorthash_keygenFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_signFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_sign_detachedFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_sign_keypairFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_sign_openFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_sign_publickeyFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_sign_publickey_from_secretkeyFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_sign_secretkeyFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_sign_seed_keypairFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_sign_verify_detachedFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_sign_ed25519_pk_to_curve25519Found"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_sign_ed25519_sk_to_curve25519Found"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_streamFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_stream_keygenFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_stream_xorFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_hex2binFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_incrementFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_library_version_majorFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_library_version_minorFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_version_stringFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_memcmpFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_memzeroFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_randombytes_bufFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_randombytes_uniformFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_randombytes_random16Found"/>
+
+        <!-- Via `symfony/polyfill-php55` -->
+        <exclude name="PHPCompatibility.PHP.NewFunctions.array_columnFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.boolvalFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.hash_pbkdf2Found"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.json_last_error_msgFound"/>
+
+        <!-- Via `symfony/polyfill-php56` -->
+        <exclude name="PHPCompatibility.PHP.NewFunctions.hash_equalsFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.ldap_escapeFound"/>
+
+        <!-- Via `symfony/polyfill-php73` -->
+        <exclude name="PHPCompatibility.PHP.NewFunctions.is_countableFound"/>
+    </rule>
+
+</ruleset>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,98 @@
+[![Latest Stable Version](https://poser.pugx.org/PHPCompatibility/phpcompatibility-joomla/v/stable.png)](https://packagist.org/packages/PHPCompatibility/phpcompatibility-joomla)
+[![Latest Unstable Version](https://poser.pugx.org/PHPCompatibility/phpcompatibility-joomla/v/unstable.png)](https://packagist.org/packages/PHPCompatibility/phpcompatibility-joomla)
+[![License](https://poser.pugx.org/PHPCompatibility/phpcompatibility-joomla/license.png)](https://github.com/PHPCompatibility/PHPCompatibilityJoomla/blob/master/LICENSE)
+[![Build Status](https://travis-ci.org/PHPCompatibility/PHPCompatibilityJoomla.png?branch=master)](https://travis-ci.org/PHPCompatibility/PHPCompatibilityJoomla)
+
 # PHPCompatibilityJoomla
-PHPCompatibility ruleset for Joomla projects
+
+Using the PHPCompatibilityJoomla standard, you can analyse the codebase of a Joomla-based project for PHP cross-version compatibility.
+
+
+## What's in this repo ?
+
+A PHPCompatibility ruleset for projects based on the Joomla CMS.
+
+This Joomla specific ruleset prevents false positives from the [PHPCompatibility standard](https://github.com/PHPCompatibility/PHPCompatibility) by excluding back-fills and poly-fills which are provided by Joomla.
+
+
+## Requirements
+
+* [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer).
+    * PHP 5.3+ for use with [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) 2.3.0+.
+    * PHP 5.4+ for use with [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) 3.0.2+.
+
+    Use the latest stable release of PHP_CodeSniffer for the best results.
+    The minimum _recommended_ version of PHP_CodeSniffer is PHPCS 2.6.0.
+* [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility).
+
+
+## Installation instructions
+
+### Installation instructions using Composer
+
+If you don't have a Composer plugin installed to manage the `installed_paths` setting for PHP_CodeSniffer, run the following from the command-line:
+```bash
+composer require --dev dealerdirect/phpcodesniffer-composer-installer:^0.4.3 phpcompatibility/phpcompatibility-joomla:*
+composer install
+```
+
+If you already have a Composer PHPCS plugin installed, run:
+```bash
+composer require --dev phpcompatibility/phpcompatibility-joomla:*
+composer install
+```
+
+Next, run:
+```bash
+vendor/bin/phpcs -i
+```
+If all went well, you will now see that the PHPCompatibility and PHPCompatibilityJoomla standards are installed for PHP_CodeSniffer.
+
+### Installation instructions without Composer (unsupported)
+
+* Install [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) via [your preferred method](https://github.com/squizlabs/PHP_CodeSniffer#installation).
+
+    PHP CodeSniffer offers a variety of installation methods to suit your work-flow: Composer, [PEAR](http://pear.php.net/PHP_CodeSniffer), a Phar file, zipped/tarred release archives or checking the repository out using Git.
+
+* Install [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) by [cloning the PHPCompatibility repository](https://github.com/PHPCompatibility/PHPCompatibility#installation-via-a-git-check-out-to-an-arbitrary-directory-method-2).
+
+* Install [PHPCompatibilityJoomla](https://github.com/PHPCompatibility/PHPCompatibilityJoomla) by cloning this repository.
+
+* Add the paths to the directories in which you placed your copies of the PHPCompatibility repo and the PHPCompatibilityJoomla repo to the PHP CodeSniffer configuration using the below command from the command line:
+   ```bash
+   phpcs --config-set installed_paths /path/to/PHPCompatibility,/path/to/PHPCompatibilityJoomla
+   ```
+   For more information, see the PHP CodeSniffer wiki on the [`installed_paths` configuration variable](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-installed-standard-paths).
+
+* Verify that the PHPCompatibility standard is registered correctly by running `phpcs -i` on the command line. PHPCompatibility should be listed as one of the available standards.
+
+
+## How to use
+
+Now you can use the following command to inspect your code:
+```bash
+./vendor/bin/phpcs -p . --standard=PHPCompatibilityJoomla
+
+# Or if you installed without using Composer:
+phpcs -p . --standard=PHPCompatibilityJoomla
+```
+
+By default, you will only receive notifications about deprecated and/or removed PHP features.
+
+To get the most out of the PHPCompatibilityJoomla standard, you should specify a `testVersion` to check against. That will enable the checks for both deprecated/removed PHP features as well as the detection of code using new PHP features.
+
+The minimum PHP requirement of the Joomla project at this time is PHP 5.3.10. If you want to enforce this, either add `--runtime-set testVersion 5.3-` to your command-line command or add `<config name="testVersion" value="5.3-"/>` to your [custom ruleset](https://github.com/PHPCompatibility/PHPCompatibility#using-a-custom-ruleset).
+
+For more detailed information about setting the `testVersion`, see the README of the generic [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions) standard.
+
+
+## License
+
+All code within the PHPCompatibility organisation is released under the GNU Lesser General Public License (LGPL). For more information, visit https://www.gnu.org/copyleft/lesser.html
+
+
+## Changelog
+
+### 1.0.0 - 2018-07-17
+
+Initial release of the PHPCompatibilityJoomla ruleset.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,32 @@
+{
+  "name" : "phpcompatibility/phpcompatibility-joomla",
+  "description" : "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility for Joomla projects.",
+  "type" : "phpcodesniffer-standard",
+  "keywords" : [ "compatibility", "phpcs", "standards", "joomla" ],
+  "homepage" : "http://phpcompatibility.com/",
+  "license" : "LGPL-3.0-or-later",
+  "authors" : [ {
+    "name" : "Wim Godden",
+    "role" : "lead"
+  },
+  {
+    "name" : "Juliette Reinders Folmer",
+    "role" : "lead"
+  },
+  {
+    "name" : "Mihael Babker",
+    "role" : "Joomla specialist"
+  } ],
+  "support" : {
+    "issues" : "https://github.com/PHPCompatibility/PHPCompatibilityJoomla/issues",
+    "source" : "https://github.com/PHPCompatibility/PHPCompatibilityJoomla"
+  },
+  "require" : {
+    "phpcompatibility/php-compatibility" : "*"
+  },
+  "suggest" : {
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+    "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+  },
+  "prefer-stable" : true
+}


### PR DESCRIPTION
- Adds the Joomla specific PHPCompatibility ruleset.
- Adds README with basic installation and usage instructions.
- Adds `composer.json` file which requires the PHPCompatibility standard.
- Adds a Travis config to validate the ruleset XML and the Composer configuration on each update.
- Adds `.gitignore` to ignore the `vendor` directory and the `composer.lock` file.
- Adds `.gitattributes` to keep release archives clean.
- Adds `.github/issue_template.md` to try and prevent issues related to the generic PHPCompatibility standard from being opened in this repository.