### PR TITLE
Version 2.0.0 / Update for PHPCompatibility 9.0.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,8 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.travis.yml export-ignore
-/.github export-ignore
+/.github/ export-ignore
+/Test/ export-ignore
 
 #
 # Auto detect text files and perform LF normalization

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -3,7 +3,7 @@ This repository is only for the Joomla PHPCompatibility ruleset, which prevents 
 
 If your issue is related to the PHPCompatibility sniffs, please open an issue in the PHPCompatibility repository: https://github.com/PHPCompatibility/PHPCompatibility/issues
 
-Before opening a new issue, please search for duplicate issues to prevent opening a duplicate. If there is already an open issue, please leave a comment there.
+Before opening a new issue, please search for your issue to prevent opening a duplicate. If there is already an open issue, please leave a comment there.
 
 If you are opening an issue to get a new back-fill / poly-fill which was added to Joomla excluded, please include links to the Joomla source code to substantiate your request.
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ language: php
 ## Cache composer downloads.
 cache:
   directories:
-    # Cache directory for older Composer versions.
-    - $HOME/.composer/cache/files
-    # Cache directory for more recent Composer versions.
     - $HOME/.cache/composer/files
 
 matrix:
@@ -30,6 +27,7 @@ before_install:
   - if [[ $COVERALLS_VERSION == "notset" ]]; then phpenv config-rm xdebug.ini || echo 'No xdebug config.'; fi
   - export XMLLINT_INDENT="    "
   - composer install
+  - vendor/bin/phpcs -i
 
 script:
   - |
@@ -41,6 +39,9 @@ script:
       # Check the code-style consistency of the xml file.
       diff -B ./PHPCompatibilityJoomla/ruleset.xml <(xmllint --format "./PHPCompatibilityJoomla/ruleset.xml")
     fi
+
+  # Test the ruleset.
+  - vendor/bin/phpcs ./Test/JoomlaTest.php --standard=PHPCompatibilityJoomla --runtime-set testVersion 5.3
 
   # Validate the composer.json file.
   # @link https://getcomposer.org/doc/03-cli.md#validate

--- a/PHPCompatibilityJoomla/ruleset.xml
+++ b/PHPCompatibilityJoomla/ruleset.xml
@@ -4,7 +4,7 @@
 
     <!--
     The Joomla minimum PHP requirement is PHP 5.3.10.
-    Add the following in your project PHPCS ruleset to enforce this:
+    Add the following in your project PHP_CodeSniffer ruleset to enforce this:
     <config name="testVersion" value="5.3-"/>
 
     This directive is not included in this ruleset as individual projects may use
@@ -12,167 +12,19 @@
     -->
 
     <rule ref="PHPCompatibility">
-        <!-- Via `ircmaxell/password-compat` -->
-        <exclude name="PHPCompatibility.PHP.NewConstants.password_bcryptFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.password_bcrypt_default_costFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.password_defaultFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.password_get_infoFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.password_hashFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.password_needs_rehashFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.password_verifyFound"/>
-
-        <!-- Via `joomla/compat` -->
-        <exclude name="PHPCompatibility.PHP.NewClasses.callbackfilteriteratorFound"/>
-        <exclude name="PHPCompatibility.PHP.NewInterfaces.jsonserializableFound"/>
-
-        <!-- Via `paragonie/random_compat` -->
-        <exclude name="PHPCompatibility.PHP.NewClasses.errorFound"/>
-        <exclude name="PHPCompatibility.PHP.NewClasses.typeerrorFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.random_intFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.random_bytesFound"/>
-
-        <!-- Via `paragonie/sodium_compat` -->
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_aead_chacha20poly1305_keybytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_aead_chacha20poly1305_nsecbytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_aead_chacha20poly1305_npubbytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_aead_chacha20poly1305_abytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_aead_aes256gcm_keybytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_aead_aes256gcm_nsecbytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_aead_aes256gcm_npubbytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_aead_aes256gcm_abytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_aead_chacha20poly1305_ietf_keybytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_aead_chacha20poly1305_ietf_nsecbytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_aead_chacha20poly1305_ietf_npubbytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_aead_chacha20poly1305_ietf_abytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_auth_bytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_auth_keybytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_box_sealbytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_box_secretkeybytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_box_publickeybytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_box_keypairbytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_box_macbytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_box_noncebytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_box_seedbytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_kx_bytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_kx_publickeybytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_kx_secretkeybytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_kx_seedbytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_generichash_bytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_generichash_bytes_minFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_generichash_bytes_maxFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_generichash_keybytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_generichash_keybytes_minFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_generichash_keybytes_maxFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_pwhash_saltbytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_pwhash_strprefixFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_pwhash_alg_argon2i13Found"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_pwhash_alg_argon2id13Found"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_pwhash_memlimit_interactiveFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_pwhash_opslimit_interactiveFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_pwhash_memlimit_moderateFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_pwhash_opslimit_moderateFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_pwhash_memlimit_sensitiveFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_pwhash_opslimit_sensitiveFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_scalarmult_bytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_scalarmult_scalarbytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_shorthash_bytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_shorthash_keybytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_secretbox_keybytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_secretbox_macbytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_secretbox_noncebytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_sign_bytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_sign_seedbytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_sign_publickeybytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_sign_secretkeybytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_sign_keypairbytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_stream_keybytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewConstants.sodium_crypto_stream_noncebytesFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_bin2hexFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_compareFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_aead_aes256gcm_decryptFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_aead_aes256gcm_encryptFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_aead_aes256gcm_is_availableFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_aead_chacha20poly1305_decryptFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_aead_chacha20poly1305_encryptFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_aead_chacha20poly1305_keygenFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_aead_chacha20poly1305_ietf_decryptFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_aead_chacha20poly1305_ietf_encryptFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_aead_chacha20poly1305_ietf_keygenFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_aead_xchacha20poly1305_ietf_decryptFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_aead_xchacha20poly1305_ietf_encryptFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_aead_xchacha20poly1305_ietf_keygenFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_authFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_auth_keygenFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_auth_verifyFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_boxFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_box_keypairFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_box_keypair_from_secretkey_and_publickeyFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_box_openFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_box_publickeyFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_box_publickey_from_secretkeyFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_box_sealFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_box_seal_openFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_box_secretkeyFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_box_seed_keypairFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_generichashFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_generichash_finalFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_generichash_initFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_generichash_keygenFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_generichash_updateFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_kxFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_pwhashFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_pwhash_strFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_pwhash_str_verifyFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_pwhash_scryptsalsa208sha256Found"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_pwhash_scryptsalsa208sha256_strFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_pwhash_scryptsalsa208sha256_str_verifyFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_scalarmultFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_scalarmult_baseFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_secretboxFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_secretbox_keygenFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_secretbox_openFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_shorthashFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_shorthash_keygenFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_signFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_sign_detachedFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_sign_keypairFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_sign_openFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_sign_publickeyFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_sign_publickey_from_secretkeyFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_sign_secretkeyFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_sign_seed_keypairFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_sign_verify_detachedFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_sign_ed25519_pk_to_curve25519Found"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_sign_ed25519_sk_to_curve25519Found"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_streamFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_stream_keygenFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_crypto_stream_xorFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_hex2binFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_incrementFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_library_version_majorFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_library_version_minorFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_version_stringFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_memcmpFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_memzeroFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_randombytes_bufFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_randombytes_uniformFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.sodium_randombytes_random16Found"/>
-
-        <!-- Via `symfony/polyfill-php55` -->
-        <exclude name="PHPCompatibility.PHP.NewFunctions.array_columnFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.boolvalFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.hash_pbkdf2Found"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.json_last_error_msgFound"/>
-
-        <!-- Via `symfony/polyfill-php56` -->
-        <exclude name="PHPCompatibility.PHP.NewFunctions.hash_equalsFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.ldap_escapeFound"/>
-
-        <!-- Via `symfony/polyfill-php73` -->
-        <exclude name="PHPCompatibility.PHP.NewFunctions.is_countableFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.hrtimeFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.array_key_firstFound"/>
-        <exclude name="PHPCompatibility.PHP.NewFunctions.array_key_lastFound"/>
+        <!-- https://github.com/joomla-framework/compat/tree/master/src -->
+        <exclude name="PHPCompatibility.Classes.NewClasses.callbackfilteriteratorFound"/>
+        <exclude name="PHPCompatibility.Interfaces.NewInterfaces.jsonserializableFound"/>
     </rule>
+
+    <!-- https://github.com/joomla/joomla-cms/blob/staging/composer.json -->
+
+    <!-- Includes Paragonie random_compat. -->
+    <rule ref="PHPCompatibilityParagonieSodiumCompat"/>
+
+    <!-- Includes ircmaxell password_compat. -->
+    <rule ref="PHPCompatibilitySymfonyPolyfillPHP55"/>
+    <rule ref="PHPCompatibilitySymfonyPolyfillPHP56"/>
+    <rule ref="PHPCompatibilitySymfonyPolyfillPHP73"/>
 
 </ruleset>

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-[![Latest Stable Version](https://poser.pugx.org/PHPCompatibility/phpcompatibility-joomla/v/stable.png)](https://packagist.org/packages/PHPCompatibility/phpcompatibility-joomla)
-[![Latest Unstable Version](https://poser.pugx.org/PHPCompatibility/phpcompatibility-joomla/v/unstable.png)](https://packagist.org/packages/PHPCompatibility/phpcompatibility-joomla)
-[![License](https://poser.pugx.org/PHPCompatibility/phpcompatibility-joomla/license.png)](https://github.com/PHPCompatibility/PHPCompatibilityJoomla/blob/master/LICENSE)
+[![Latest Stable Version](https://poser.pugx.org/phpcompatibility/phpcompatibility-joomla/v/stable.png)](https://packagist.org/packages/phpcompatibility/phpcompatibility-joomla)
+[![Latest Unstable Version](https://poser.pugx.org/phpcompatibility/phpcompatibility-joomla/v/unstable.png)](https://packagist.org/packages/phpcompatibility/phpcompatibility-joomla)
+[![License](https://poser.pugx.org/phpcompatibility/phpcompatibility-joomla/license.png)](https://github.com/PHPCompatibility/PHPCompatibilityJoomla/blob/master/LICENSE)
 [![Build Status](https://travis-ci.org/PHPCompatibility/PHPCompatibilityJoomla.svg?branch=master)](https://travis-ci.org/PHPCompatibility/PHPCompatibilityJoomla)
 
 # PHPCompatibilityJoomla
 
-Using the PHPCompatibilityJoomla standard, you can analyse the codebase of a Joomla-based project for PHP cross-version compatibility.
+Using PHPCompatibilityJoomla, you can analyse the codebase of a Joomla-based project for PHP cross-version compatibility.
 
 
 ## What's in this repo ?
 
-A PHPCompatibility ruleset for projects based on the Joomla CMS.
+A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects based on the Joomla CMS.
 
 This Joomla specific ruleset prevents false positives from the [PHPCompatibility standard](https://github.com/PHPCompatibility/PHPCompatibility) by excluding back-fills and poly-fills which are provided by Joomla.
 
@@ -22,13 +22,16 @@ This Joomla specific ruleset prevents false positives from the [PHPCompatibility
     * PHP 5.4+ for use with [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) 3.0.2+.
 
     Use the latest stable release of PHP_CodeSniffer for the best results.
-    The minimum _recommended_ version of PHP_CodeSniffer is PHPCS 2.6.0.
-* [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility).
+    The minimum _recommended_ version of PHP_CodeSniffer is version 2.6.0.
+* [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) 9.0.0+.
+* [PHPCompatibilityParagonie](https://github.com/PHPCompatibility/PHPCompatibilityParagonie) 1.0.0+.
+* [PHPCompatibilityPasswordCompat](https://github.com/PHPCompatibility/PHPCompatibilityPasswordCompat) 1.0.0+.
+* [PHPCompatibilitySymfony](https://github.com/PHPCompatibility/PHPCompatibilitySymfony) 1.0.0+.
 
 
 ## Installation instructions
 
-### Installation instructions using Composer
+The only supported installation method is via [Composer](https://getcomposer.org/).
 
 If you don't have a Composer plugin installed to manage the `installed_paths` setting for PHP_CodeSniffer, run the following from the command-line:
 ```bash
@@ -36,7 +39,7 @@ composer require --dev dealerdirect/phpcodesniffer-composer-installer:^0.4.3 php
 composer install
 ```
 
-If you already have a Composer PHPCS plugin installed, run:
+If you already have a Composer PHP_CodeSniffer plugin installed, run:
 ```bash
 composer require --dev phpcompatibility/phpcompatibility-joomla:*
 composer install
@@ -46,25 +49,7 @@ Next, run:
 ```bash
 vendor/bin/phpcs -i
 ```
-If all went well, you will now see that the PHPCompatibility and PHPCompatibilityJoomla standards are installed for PHP_CodeSniffer.
-
-### Installation instructions without Composer (unsupported)
-
-* Install [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) via [your preferred method](https://github.com/squizlabs/PHP_CodeSniffer#installation).
-
-    PHP CodeSniffer offers a variety of installation methods to suit your work-flow: Composer, [PEAR](http://pear.php.net/PHP_CodeSniffer), a Phar file, zipped/tarred release archives or checking the repository out using Git.
-
-* Install [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) by [cloning the PHPCompatibility repository](https://github.com/PHPCompatibility/PHPCompatibility#installation-via-a-git-check-out-to-an-arbitrary-directory-method-2).
-
-* Install [PHPCompatibilityJoomla](https://github.com/PHPCompatibility/PHPCompatibilityJoomla) by cloning this repository.
-
-* Add the paths to the directories in which you placed your copies of the PHPCompatibility repo and the PHPCompatibilityJoomla repo to the PHP CodeSniffer configuration using the below command from the command line:
-   ```bash
-   phpcs --config-set installed_paths /path/to/PHPCompatibility,/path/to/PHPCompatibilityJoomla
-   ```
-   For more information, see the PHP CodeSniffer wiki on the [`installed_paths` configuration variable](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-installed-standard-paths).
-
-* Verify that the PHPCompatibility standard is registered correctly by running `phpcs -i` on the command line. PHPCompatibility should be listed as one of the available standards.
+If all went well, you will now see that the `PHPCompatibility`, `PHPCompatibilityJoomla` and several other PHPCompatibility standards are installed for PHP_CodeSniffer.
 
 
 ## How to use
@@ -72,9 +57,6 @@ If all went well, you will now see that the PHPCompatibility and PHPCompatibilit
 Now you can use the following command to inspect your code:
 ```bash
 ./vendor/bin/phpcs -p . --standard=PHPCompatibilityJoomla
-
-# Or if you installed without using Composer:
-phpcs -p . --standard=PHPCompatibilityJoomla
 ```
 
 By default, you will only receive notifications about deprecated and/or removed PHP features.
@@ -83,8 +65,21 @@ To get the most out of the PHPCompatibilityJoomla standard, you should specify a
 
 The minimum PHP requirement of the Joomla project at this time is PHP 5.3.10. If you want to enforce this, either add `--runtime-set testVersion 5.3-` to your command-line command or add `<config name="testVersion" value="5.3-"/>` to your [custom ruleset](https://github.com/PHPCompatibility/PHPCompatibility#using-a-custom-ruleset).
 
+For example:
+```bash
+# For a project which should be compatible with PHP 5.3 and higher:
+./vendor/bin/phpcs -p . --standard=PHPCompatibilityJoomla --runtime-set testVersion 5.3-
+```
+
 For more detailed information about setting the `testVersion`, see the README of the generic [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions) standard.
 
+
+### Testing PHP files only
+
+By default PHP_CodeSniffer will analyse PHP, JavaScript and CSS files. As the PHPCompatibility sniffs only target PHP code, you can make the run slightly faster by telling PHP_CodeSniffer to only check PHP files, like so:
+```bash
+./vendor/bin/phpcs -p . --standard=PHPCompatibilityJoomla --extensions=php --runtime-set testVersion 5.3-
+```
 
 ## License
 
@@ -92,6 +87,14 @@ All code within the PHPCompatibility organisation is released under the GNU Less
 
 
 ## Changelog
+
+### 2.0.0 - 2018-10-07
+
+- Ruleset: Updated for Joomla 3.9.
+- Ruleset: Updated for compatibility with PHPCompatibility 9.0+.
+- Composer: Added dependencies for the dedicated polyfill-based PHPCompatibility rulesets.
+- CI: Added a test for the ruleset.
+- Readme: Removed the installation instructions for a non-Composer based install.
 
 ### 1.0.0 - 2018-07-17
 

--- a/Test/JoomlaTest.php
+++ b/Test/JoomlaTest.php
@@ -1,0 +1,10 @@
+<?php
+/*
+ * Test file to run PHP_CodeSniffer against to make sure the polyfills are correctly excluded.
+ *
+ * This file should only test the polyfills provided by Joomla itself.
+ * The polyfills provided via dependencies will be tested via the repo containing
+ * the dedicated ruleset(s) for those dependencies.
+ */
+class ABC extends CallbackFilterIterator {}
+class DEF implements JsonSerializable {}

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name" : "phpcompatibility/phpcompatibility-joomla",
-  "description" : "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility for Joomla projects.",
+  "description" : "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by Joomla.",
   "type" : "phpcodesniffer-standard",
   "keywords" : [ "compatibility", "phpcs", "standards", "joomla" ],
   "homepage" : "http://phpcompatibility.com/",
@@ -22,10 +22,15 @@
     "source" : "https://github.com/PHPCompatibility/PHPCompatibilityJoomla"
   },
   "require" : {
-    "phpcompatibility/php-compatibility" : "^8.1"
+    "phpcompatibility/php-compatibility" : "^9.0",
+    "phpcompatibility/phpcompatibility-paragonie" : "^1.0",
+    "phpcompatibility/phpcompatibility-symfony" : "^1.0"
+  },
+  "require-dev" : {
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
   },
   "suggest" : {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
     "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
   },
   "prefer-stable" : true


### PR DESCRIPTION
:warning: **IMPORTANT** :warning:
The build for this PR will not pass until PHPCompatibility 9.0.0 and the polyfill rulesets has been released.  This PR should not be merged until then. 

---

This update accounts for the following changes:
* Ruleset:
    - Updated sniff error codes for compatibility with PHPCompatibility 9.0.0.
    - Defer to the dedicated polyfill rulesets for polyfills provided by project dependencies.
    - Add links to where the polyfills are declared for easier future verification.
* Composer:
    - Require relevant dedicated polyfill rulesets.
    - Require `dev` the DealerDirect PHPCS Composer plugin to sort out the `installed_paths` so Travis can test the ruleset.
    - Improved the project description.
* Travis/Tests:
    - Added testing of the ruleset.
* Issue template: minor textual tweak.
* Readme:
    - Added information about the dependency on the polyfill rulesets.
    - Removed non-Composer installation instructions.
        As there are now more dependencies for this project, installation without using Composer, while of course still possible, is no longer _supported_.
    - Added section about only testing PHP files. See #5
    - Added changelog for version 2.0.0.

Additionally, in all user-facing texts, the abbreviation `PHPCS` has been expanded to read `PHP_CodeSniffer`.

Fixes #5

----

Additional notes:
* The changes in [PHPCompatibility 9.0.0](https://github.com/PHPCompatibility/PHPCompatibility/pull/741) warrant for this release to be a major release again.
    To that end, I've re-milestoned the PRs which had been merged so far to the `2.0.0` milestone.
* @mbabker The two Joomla "native" polyfills come from the `joomla/compat` package, however, that package looks to be [deprecated](https://github.com/joomla-framework/compat) and is no longer included in the [`composer.json` file](https://github.com/joomla/joomla-cms/blob/staging/composer.json), though it is still in the [committed `vendor` directory](https://github.com/joomla/joomla-cms/tree/staging/libraries/vendor/joomla/compat/src).
    Any idea what's going on and how those methods will be provided to the CMS for version 3.9 ?