### PR TITLE
Add PHP 7.1 polyfill

### DIFF
--- a/PHPCompatibilityJoomla/ruleset.xml
+++ b/PHPCompatibilityJoomla/ruleset.xml
@@ -25,6 +25,7 @@
     <!-- Includes ircmaxell password_compat. -->
     <rule ref="PHPCompatibilitySymfonyPolyfillPHP55"/>
     <rule ref="PHPCompatibilitySymfonyPolyfillPHP56"/>
+    <rule ref="PHPCompatibilitySymfonyPolyfillPHP71"/>
     <rule ref="PHPCompatibilitySymfonyPolyfillPHP73"/>
 
 </ruleset>


### PR DESCRIPTION
We pulled in the `symfony/polyfill-php71` package for our 3.9 release.  This is the corresponding update for the ruleset.