### PR TITLE
Composer: update recommended Composer PHPCS installed version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,10 @@
     "phpcompatibility/phpcompatibility-symfony" : "^1.0"
   },
   "require-dev" : {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.5"
   },
   "suggest" : {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
     "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
   },
   "prefer-stable" : true


### PR DESCRIPTION
Composer treats minors before 1.0.0 as majors. As the DealerDirect plugin has released version 0.5.0 a while back, we should recommend people to use that version instead and use it ourselves as well.

Refs:
* https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases/tag/v0.5.0
* https://getcomposer.org/doc/articles/versions.md#caret-version-range-