### PR TITLE
Update reference to the DealerDirect plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The only supported installation method is via [Composer](https://getcomposer.org
 
 If you don't have a Composer plugin installed to manage the `installed_paths` setting for PHP_CodeSniffer, run the following from the command-line:
 ```bash
-composer require --dev dealerdirect/phpcodesniffer-composer-installer:^0.4.3 phpcompatibility/phpcompatibility-joomla:*
+composer require --dev dealerdirect/phpcodesniffer-composer-installer:^0.5.0 phpcompatibility/phpcompatibility-joomla:*
 composer install
 ```
 


### PR DESCRIPTION
PR #12 updated the `composer.json` file to recommend version `^0.5.0` of the DealerDirect plugin, but the installation instructions in the readme hadn't been updated yet to reflect this.