### PR TITLE
Changelog for the release of PHPCompatibilityJoomla 2.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,16 @@ All code within the PHPCompatibility organisation is released under the GNU Less
 
 ## Changelog
 
+### 2.1.2 - 2021-02-15
+
+- The recommended version of the [Composer PHPCS plugin] is now `^0.7.0`, which offers compatibility with Composer 2.0.
+- The ruleset is now also tested against PHP 7.4 and 8.0.
+    Note: full PHP 7.4 support is only available in combination with PHP_CodeSniffer >= 3.5.6.
+    Note: runtime PHP 8.0 support is only available in combination with PHP_CodeSniffer >= 3.5.7, full support is expected in PHP_CodeSniffer 3.6.0.
+
 ### 2.1.1 - 2019-08-29
 
-- The recommended version of the DealerDirect PHPCS Composer plugin is now `^0.5.0`.
+- The recommended version of the [Composer PHPCS plugin] is now `^0.5.0`.
 
 ### 2.1.0 - 2018-12-16
 
@@ -109,3 +116,5 @@ All code within the PHPCompatibility organisation is released under the GNU Less
 ### 1.0.0 - 2018-07-17
 
 Initial release of the PHPCompatibilityJoomla ruleset.
+
+[Composer PHPCS plugin]: https://github.com/Dealerdirect/phpcodesniffer-composer-installer/


### PR DESCRIPTION
@mbabker FYI: This is just a small release to offload any changes made in the interim ahead of the next major, which will include PHPCompatibility 10.0.0 (expected soonish).
I will tag the release after I've updated and released a similar release for the PHPCompatibilitySymfony repo to make sure that when people update, they will get the latest version of the underlying packages as well. (The PHPCompatibilityParagonie repo has already had a new release earlier today).