### PR TITLE
Add "static analysis" Composer keyword

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name" : "phpcompatibility/phpcompatibility-joomla",
   "description" : "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by Joomla.",
   "type" : "phpcodesniffer-standard",
-  "keywords" : [ "compatibility", "phpcs", "standards", "joomla" ],
+  "keywords" : [ "compatibility", "phpcs", "standards", "static analysis", "joomla" ],
   "homepage" : "http://phpcompatibility.com/",
   "license" : "LGPL-3.0-or-later",
   "authors" : [ {


### PR DESCRIPTION
As per https://getcomposer.org/doc/04-schema.md#keywords by including "static analysis" as a keyword in the `composer.json` file, Composer 2.4.0-RC1 and later will prompt users if the package is installed with `composer require` instead of `composer require --dev`. See https://github.com/composer/composer/pull/10960 for more info.