### PR TITLE
Changelog for the release of PHPCompatibilityJoomla 2.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ All code within the PHPCompatibility organisation is released under the GNU Less
 
 ## Changelog
 
+### 2.1.3 - 2022-10-23
+
+- README: Updated the installation instructions for [compatibility with Composer >= 2.2][composer22announce].
+- Composer: The package will now identify itself as a static analysis tool. Thanks [@GaryJones]!
+- Other housekeeping and minor documentation updates.
+
+[composer22announce]: https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution
+
 ### 2.1.2 - 2021-02-15
 
 - The recommended version of the [Composer PHPCS plugin] is now `^0.7.0`, which offers compatibility with Composer 2.0.
@@ -116,4 +124,6 @@ All code within the PHPCompatibility organisation is released under the GNU Less
 
 Initial release of the PHPCompatibilityJoomla ruleset.
 
-[Composer PHPCS plugin]: https://github.com/Dealerdirect/phpcodesniffer-composer-installer/
+[Composer PHPCS plugin]: https://github.com/PHPCSStandards/composer-installer/
+
+[@GaryJones]: https://github.com/GaryJones


### PR DESCRIPTION
@mbabker Well, after lots of delays, we're finally close to PHPCompatibility 10.0.0... pfff
So.. this is just a small release to offload any changes made in the interim ahead of the next major.
I will tag the release after I've updated and released a similar release for the other PHPCompatibility* repos to make sure that when people update, they will get the latest version of the underlying packages as well.

Are there any changes in the polyfills Joomla provides which should be included still ?